### PR TITLE
Feature/cache comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,30 @@ based firewall. These are
 Some of these scripts originate from elsewhere and have been modified across
 time to suit my own needs. I have lost track of their origin and I hope their
 original authors allow their republication here. Please raise an issue!
+
+## Developer Notes
+
+You can use Docker to exercise and test these scripts without touching your host
+system. The following command, run from this directory, should make the scripts
+available at `/dynufw`:
+
+```shell
+docker run \
+    -it --rm \
+    -v $(pwd):/dynufw \
+    --cap-add=NET_ADMIN --cap-add=NET_RAW \
+    ubuntu
+```
+
+Then, from within the container, install `ufw` using:
+
+```shell
+apt update && apt install -y ufw
+```
+
+Finally, manually disable IPv6, by setting the value of `IPV6` to `no` in
+`/etc/default/ufw`.
+
+```shell
+sed -e 's/IPV6=.*/IPV6=no/g'  -i  /etc/default/ufw
+```

--- a/ufw-dynamic-host-update.sh
+++ b/ufw-dynamic-host-update.sh
@@ -34,7 +34,7 @@ Usage:
     -s | --server        Server to use for DNS resolutions, whenever possible
     --ufw                Location of the ufw binary, defaults to ufw
     --respit             Time to wait between rule changes, defaults to 1
-    --quiet              Be almost silence, only warnings.
+    --quiet              Be almost silent, only warnings.
     -v | --verbose       Be more verbose
     -h | --help          Print this help and exit.
 USAGE
@@ -192,14 +192,16 @@ do
 
     # When the IP is lost, delete the rule. When the IP has changed, delete the
     # old rule and create a new one.
-    if [ -z "${ip}" ]; then
-        if [ -n "${old_ip}" ]; then
+    if [ -z "$ip" ]; then
+        if [ -n "$old_ip" ]; then
             delete_rule "$proto" "$port" "$old_ip"
         fi
         warn "Failed to resolve the ip address of $host."
     else
-        if { [ -n "$old_ip" ] && [ "$ip" != "$old_ip" ]; } || [ "$FORCE" = "1" ]; then
-            delete_rule "$proto" "$port" "$old_ip"
+        if [ -n "$old_ip" ]; then
+            if [ "$ip" != "$old_ip" ] || [ "$FORCE" = "1" ]; then
+                delete_rule "$proto" "$port" "$old_ip"
+            fi
         fi
         add_rule "$proto" "$port" "$ip" "$host"
     fi


### PR DESCRIPTION
This uses the `comment` field of `ufw` rules to store the name of the host leading to the rules. In practice, this removes the cache file that used to map hostnames onto IP addresses.